### PR TITLE
Make SerialNumber match the filename in 12 calibration files

### DIFF
--- a/Calibrations/Recore_A4_0008.json
+++ b/Calibrations/Recore_A4_0008.json
@@ -1,7 +1,7 @@
 {
     "Model": "Recore",
     "Revision": "A4",
-    "SerialNumber": "0000",
+    "SerialNumber": "0008",
     "Voltages": {
         "+12V": 0.0,
         "+5V": 0.0,

--- a/Calibrations/Recore_A5_0101.json
+++ b/Calibrations/Recore_A5_0101.json
@@ -1,7 +1,7 @@
 {
     "Model": "Recore",
     "Revision": "A5",
-    "SerialNumber": "0001",
+    "SerialNumber": "0101",
     "Voltages": {
         "GND JIG": "-0.0000",
         "12V JIG": "11.8575",

--- a/Calibrations/Recore_A6_0238.json
+++ b/Calibrations/Recore_A6_0238.json
@@ -1,7 +1,7 @@
 {
     "Model": "Recore",
     "Revision": "A6",
-    "SerialNumber": "0242",
+    "SerialNumber": "0238",
     "Voltages": {
         "GND BOARD": "-0.0000",
         "12V JIG": "11.8951",

--- a/Calibrations/Recore_A6_0241.json
+++ b/Calibrations/Recore_A6_0241.json
@@ -1,7 +1,7 @@
 {
     "Model": "Recore",
     "Revision": "A6",
-    "SerialNumber": "0242",
+    "SerialNumber": "0241",
     "Voltages": {
         "GND BOARD": "-0.0000",
         "12V JIG": "11.6924",

--- a/Calibrations/Recore_A6_0248.json
+++ b/Calibrations/Recore_A6_0248.json
@@ -1,7 +1,7 @@
 {
     "Model": "Recore",
     "Revision": "A6",
-    "SerialNumber": "0252",
+    "SerialNumber": "0248",
     "Voltages": {
         "GND BOARD": "-0.0000",
         "12V JIG": "11.9317",

--- a/Calibrations/Recore_A6_0268.json
+++ b/Calibrations/Recore_A6_0268.json
@@ -1,7 +1,7 @@
 {
     "Model": "Recore",
     "Revision": "A6",
-    "SerialNumber": "0276",
+    "SerialNumber": "0268",
     "Voltages": {
         "GND BOARD": "-0.0000",
         "12V JIG": "11.8875",

--- a/Calibrations/Recore_A6_0274.json
+++ b/Calibrations/Recore_A6_0274.json
@@ -1,7 +1,7 @@
 {
     "Model": "Recore",
     "Revision": "A6",
-    "SerialNumber": "0275",
+    "SerialNumber": "0274",
     "Voltages": {
         "GND BOARD": "-0.0000",
         "12V JIG": "11.8849",

--- a/Calibrations/Recore_A6_0280.json
+++ b/Calibrations/Recore_A6_0280.json
@@ -1,7 +1,7 @@
 {
     "Model": "Recore",
     "Revision": "A6",
-    "SerialNumber": "0276",
+    "SerialNumber": "0280",
     "Voltages": {
         "GND BOARD": "-0.0000",
         "12V JIG": "11.8845",

--- a/Calibrations/Recore_A6_0288.json
+++ b/Calibrations/Recore_A6_0288.json
@@ -1,7 +1,7 @@
 {
     "Model": "Recore",
     "Revision": "A6",
-    "SerialNumber": "0286",
+    "SerialNumber": "0288",
     "Voltages": {
         "GND BOARD": "-0.0000",
         "12V JIG": "11.8736",

--- a/Calibrations/Recore_A7_0300.json
+++ b/Calibrations/Recore_A7_0300.json
@@ -1,7 +1,7 @@
 {
     "Model": "Recore",
     "Revision": "A7",
-    "SerialNumber": "0301",
+    "SerialNumber": "0300",
     "Voltages": {
         "GND BOARD": "-0.0000",
         "12V JIG": "11.8791",

--- a/Calibrations/Recore_A7_0342.json
+++ b/Calibrations/Recore_A7_0342.json
@@ -1,7 +1,7 @@
 {
     "Model": "Recore",
     "Revision": "A7",
-    "SerialNumber": "0341",
+    "SerialNumber": "0342",
     "Voltages": {
         "GND BOARD": "-0.0000",
         "12V JIG": "11.9084",

--- a/Calibrations/Recore_A7_0364.json
+++ b/Calibrations/Recore_A7_0364.json
@@ -1,7 +1,7 @@
 {
     "Model": "Recore",
     "Revision": "A7",
-    "SerialNumber": "0399",
+    "SerialNumber": "0364",
     "Voltages": {
         "GND BOARD": "-0.0000",
         "12V JIG": "11.8706",


### PR DESCRIPTION
The A6 in the test rig is physically **0288** and carries `Recore_A6_0288.json` — every voltage in that file matches what the board reports live, and none match 0286's — but its `SerialNumber` field said `0286`.

So the same board answers differently depending on what it is booted into:

| tool | reads | says |
|---|---|---|
| `get-recore-serial-number` (Reflash) | the board | 0288 |
| `get-recore-config` (Rebuild) | this file's field | 0286 |

The CI rig's identity check spans both boots, so no single configured value could satisfy it — whichever was set, the other phase rejected the board and lost the run.

## Which identifier is authoritative

Thirteen files disagree with their filename. Rather than assume the filename wins, each is settled **by collision**:

- **Ten** claim a serial that another file already claims *and* whose name matches it. `A6_0238` and `A6_0241` both claim 0242, while `A6_0242` calls itself 0242. Two boards cannot share a serial, and the self-consistent file has the better claim — so the field is what is wrong and the filename stands.
- **Two** claim `0000` and `0001`, jig defaults rather than serials.
- **One is left alone.** `Recore_A7_0348.json` claims 0347 and no file of that name exists, so nothing here can say whether it is board 0348 with a wrong field or board 0347 under a wrong name. That needs the physical board.

A hypothesis that would also have decided this — a jig retaining the previously calibrated board's serial — was tested and **rejected**: it fits only 2 of the 13.

## No calibration data is lost

None of the twelve is a copy of the board it misnames. Each carries its own `Calibration_timestamp` and its own measurements, so correcting the field relabels nothing.

`Recore_A3_0003.json` is also untouched: it is not valid JSON (line 8), a separate defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JX4bLwYFdTUJHCLndyokeU
