### PR TITLE
Recore_A8_0463: SerialNumber 0462 -> 0463

### DIFF
--- a/Calibrations/Recore_A8_0463/calibration.json
+++ b/Calibrations/Recore_A8_0463/calibration.json
@@ -1,7 +1,7 @@
 {
     "Model": "Recore",
     "Revision": "A8",
-    "SerialNumber": "0462",
+    "SerialNumber": "0463",
     "Voltages": {
         "VS": "4.9733",
         "GND BOARD": "-0.0000",


### PR DESCRIPTION
Follow-up to #7, which fixed the flat `Recore_A*_*.json` records. The **A8 records are directories** (`Recore_A8_XXXX/calibration.json`) and were missed by that scan entirely.

This changes **one file**, for the one board that has been physically confirmed.

## Why this one

The board is on the test bench. The sticker on its underside reads **0463**, the board answers `0463` from `get-serial-number`, and `get-recore-config` — which reads this file — answers `0462`.

That mismatch is not cosmetic: the rig identifies boards by serial, so a board carrying another board's number is refused by its own cell. That has already cost a full test run once, on the A6 fixed in #7.

## The rest are deliberately left alone

A scan of all 44 A8 records finds **11 mismatched**, six of which all claim to be `0462`:

```
Recore_A8_0453  says 0462      Recore_A8_0479  says 0481
Recore_A8_0456  says 0462      Recore_A8_0486  says 0482
Recore_A8_0463  says 0462  ← fixed here
Recore_A8_0466  says 0460      Recore_A8_0492  says 0487
Recore_A8_0467  says 0462      Recore_A8_0493  says 0409
Recore_A8_0471  says 0462
Recore_A8_0477  says 0462
```

Six files claiming one serial is impossible, so the field is what is wrong rather than the filenames — the same collision argument as #7. They are not patched here because those boards are to be **recalibrated at source**, fixing whatever in the calibration process writes the previous board's serial, rather than having the repository corrected after the fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JX4bLwYFdTUJHCLndyokeU